### PR TITLE
Unescape HTML

### DIFF
--- a/twolde.py
+++ b/twolde.py
@@ -7,6 +7,7 @@ import platform
 import time
 import sched
 from datetime import datetime
+from HTMLParser import HTMLParser
 import ConfigParser
 
 CONFIG_FILENAME = 'config.ini'
@@ -174,14 +175,13 @@ def run():
                 print 'Next tweet time: {} UTC (in {} seconds)'.format(
                     next_tweet.created_at.ctime(), sleep_seconds)
 
-
                 # do retweets properly
                 if next_tweet.retweeted:
                     s.enter(max(1, sleep_seconds), 1, do_retweet,
                             [olde_api, next_tweet.retweeted_status.id])
                 else:
                     s.enter(max(1, sleep_seconds), 1, do_tweet,
-                            [olde_api, next_tweet.text,
+                            [olde_api, HTMLParser().unescape(next_tweet.text),
                              next_tweet.in_reply_to_status_id])
 
                 s.run()


### PR DESCRIPTION
Tweepy returns escaped HTML in the tweet text.

Tweepy had fixed this in https://github.com/tweepy/tweepy/issues/451 but had reverted it after https://github.com/tweepy/tweepy/issues/495.

So clients need to unescape the HTML.

Not tested in Twolde but:

``` python
$ python
Python 2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from HTMLParser import HTMLParser
>>> a = "a -&gt; b"
>>> print(a)
a -&gt; b
>>> print(HTMLParser().unescape(a))
a -> b
>>>
```

Closes #4.
